### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   pull_request:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/shawntz/clementime/security/code-scanning/1](https://github.com/shawntz/clementime/security/code-scanning/1)

To fix the problem, you should add a `permissions` block at the root level of the workflow in `.github/workflows/ci.yml`. This block should request only the minimum required privileges for the workflow; for the jobs shown, exclusive use of repository code for checks/linting suggests that only `contents: read` is needed. This will override any default permissions applied by the repository or organization, enforcing least privilege for all jobs unless individually overridden. No changes to job steps are required, only the addition of the permissions block at the top level, directly beneath the workflow name and triggers (`on`).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
