### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   pull_request:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/shawntz/clementime/security/code-scanning/2](https://github.com/shawntz/clementime/security/code-scanning/2)

To fix this problem, explicitly specify the minimal required permissions for the workflow. The best way is to add a `permissions` block at the top level of the workflow, ensuring all jobs inherit these minimal permissions unless otherwise overridden. Since these jobs only perform local code analysis and linting with no repository or API writes, `contents: read` is the appropriate choice. The fix consists of adding the following block to the top of `.github/workflows/ci.yml`, just after the `name:` or after the `on:` block for clarity and style:

```yaml
permissions:
  contents: read
```

No new imports, methods, or complex changes are needed—only this single block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
