### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,6 +137,8 @@ jobs:
   docker:
     needs: release
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Potential fix for [https://github.com/shawntz/clementime/security/code-scanning/12](https://github.com/shawntz/clementime/security/code-scanning/12)

To fix this issue, add a `permissions` block with the least privilege required to the `docker` job in `.github/workflows/release.yml`. Since this job primarily needs to read repository contents (for code, Dockerfile, README, etc.), the best solution is to set `permissions: contents: read` under the `docker` job. No extra imports or code definitions are needed—just an addition of the proper permissions under the appropriate job.

- Edit `.github/workflows/release.yml`
- Under `jobs: docker:`, add:
  ```yaml
  permissions:
    contents: read
  ```
- Place it directly after the `runs-on: ubuntu-latest` line (which is line 139).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
