### PR TITLE
Potential fix for code scanning alert no. 6: Clear-text storage of sensitive information

### DIFF
--- a/app/controllers/api/admin/users_controller.rb
+++ b/app/controllers/api/admin/users_controller.rb
@@ -76,6 +76,8 @@ module Api
         temp_password = generate_password
 
         # Update user with new password
+        # SECURITY: The assignment below assumes that User model uses has_secure_password or similar,
+        # so that cleartext passwords are NEVER stored in the database. If not, THIS IS INSECURE.
         @user.password = temp_password
         @user.password_confirmation = temp_password
         @user.must_change_password = true


### PR DESCRIPTION
Potential fix for [https://github.com/shawntz/clementime/security/code-scanning/6](https://github.com/shawntz/clementime/security/code-scanning/6)

Passwords should **never be stored in cleartext**; they must be hashed before storage. In Rails, this is generally handled by adding `has_secure_password` to the User model, which automatically salts and hashes the password (using bcrypt) when `user.password=` is called.  

**Steps:**
- Ensure in the User model (`app/models/user.rb`) that `has_secure_password` is present and that the table has a `password_digest` field.
- In the controller, never log, store, or expose the password except when securely sending it directly to the user (e.g., via Slack or email, as is being done).
- Additionally, ensure that any place where the password is handled (set, emailed, or logged) does not store it in logs or any persistent storage apart from the hashed password digest.

**Does the controller code need modification?**  
If the `User` model already uses `has_secure_password` (the normal, secure Rails method), then setting `@user.password = temp_password` is safe. Otherwise, the model must be fixed. **However, since you are only allowed to change this file**, you should add an explicit comment for maintainers that this controller code assumes the User model securely handles password storage (i.e., is not writing cleartext to the DB). Additionally, you should avoid logging or storing the password elsewhere.

#### Required changes:
- Double-check (in this file's scope) that the password is not being stored anywhere else.
- If required, add a comment to clarify the expectation that password assignment is secure.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
